### PR TITLE
Screen stretching issue fix and it now redirects to playlist when selecting a song in mobile mode.

### DIFF
--- a/SoundCloudPlayer/javascript/main.js
+++ b/SoundCloudPlayer/javascript/main.js
@@ -45,7 +45,7 @@ SoundCloudAPI.init =  function(){
 
 	SC.initialize({
 	  client_id: 'cd9be64eeb32d1741c17cb39e41d254d'
-	});
+  });
 }
 
 SoundCloudAPI.init();
@@ -100,9 +100,13 @@ SoundCloudAPI.renderTracks = function(tracks){
     button.appendChild(text);
 
     button.addEventListener('click', function(){
-
-    	SoundCloudAPI.getEmbed(track.permalink_url);
-
+      SoundCloudAPI.getEmbed(track.permalink_url);
+      //if the users screen width <= 1000 they are using mobile css
+      if (window.innerWidth <= 1000) {
+        play.style.display = "block";
+        search.style.display = "none";
+        btn.innerText = "Back To Search";
+      }
     });
 
     card.appendChild(imageDiv);
@@ -123,10 +127,10 @@ SoundCloudAPI.renderTracks = function(tracks){
 
 SoundCloudAPI.getEmbed = function(trackURL){
 	SC.oEmbed(trackURL, {
-  auto_play: true
+      auto_play: true
 }).then(function(embed){
 
-
+  console.log("URL = ", embed);
   var sideBar = document.querySelector(".js-playlist");
 
 
@@ -142,14 +146,17 @@ SoundCloudAPI.getEmbed = function(trackURL){
 var sideBar = document.querySelector(".js-playlist");
 sideBar.innerHTML  = localStorage.getItem("key");
 
+
+var play = document.getElementById("playlistBox");
+var search = document.getElementById("searchBox");
+var btn = document.getElementById("playlistBtn");
+
+
 /*
 This hides one of the col's when the button is pressed.
 Essentially just switches between the two in mobile mode
 */
 function hidePlaylist() {
-  var play = document.getElementById("playlistBox");
-  var search = document.getElementById("searchBox");
-  var btn = document.getElementById("playlistBtn");
   if (play.style.display === "none") {
     play.style.display = "block";
     search.style.display = "none";
@@ -166,9 +173,6 @@ This is to detect when the app goes into fullscreen again
 so I can reset the display on both col's
 */
 window.addEventListener('resize', function(){
-  var play = document.getElementById("playlistBox");
-  var search = document.getElementById("searchBox");
-  var btn = document.getElementById("playlistBtn");
   if(screen.width === window.innerWidth){
     play.style.display = "block";
     search.style.display = "block";

--- a/SoundCloudPlayer/javascript/main.js
+++ b/SoundCloudPlayer/javascript/main.js
@@ -102,11 +102,16 @@ SoundCloudAPI.renderTracks = function(tracks){
     button.addEventListener('click', function(){
       SoundCloudAPI.getEmbed(track.permalink_url);
       //if the users screen width <= 1000 they are using mobile css
-      if (window.innerWidth <= 1000) {
+      if (/Android|webOS|iPhone|iPad|iPod|BlackBerry|BB|PlayBook|IEMobile|Windows Phone|Kindle|Silk|Opera Mini/i.test(navigator.userAgent)) {
+        // Take the user to a different screen here.
         play.style.display = "block";
         search.style.display = "none";
         btn.innerText = "Back To Search";
+        console.log('Click!');
       }
+      //if (window.innerWidth <= 1000) {
+
+      //}
     });
 
     card.appendChild(imageDiv);

--- a/SoundCloudPlayer/javascript/main.js
+++ b/SoundCloudPlayer/javascript/main.js
@@ -61,6 +61,9 @@ SoundCloudAPI.getTrack = function(inputValue){
 }
 
 
+var play = document.getElementById("playlistBox");
+var search = document.getElementById("searchBox");
+var btn = document.getElementById("playlistBtn");
 
 SoundCloudAPI.renderTracks = function(tracks){
 
@@ -147,11 +150,6 @@ var sideBar = document.querySelector(".js-playlist");
 sideBar.innerHTML  = localStorage.getItem("key");
 
 
-var play = document.getElementById("playlistBox");
-var search = document.getElementById("searchBox");
-var btn = document.getElementById("playlistBtn");
-
-
 /*
 This hides one of the col's when the button is pressed.
 Essentially just switches between the two in mobile mode
@@ -173,8 +171,11 @@ This is to detect when the app goes into fullscreen again
 so I can reset the display on both col's
 */
 window.addEventListener('resize', function(){
-  if(screen.width === window.innerWidth){
+  if(screen.width >= 1001){
     play.style.display = "block";
+    search.style.display = "block";
+  } else if (screen.width <= 1000) {
+    play.style.display = "none";
     search.style.display = "block";
   }
 });

--- a/SoundCloudPlayer/styles/main.css
+++ b/SoundCloudPlayer/styles/main.css
@@ -66,8 +66,8 @@ html, body {
 }
 
 .image-img{
-	width: 100%;
-	height:100%;
+	width: 290px;
+	height:290px;
 }
 
 #playlistBtn {
@@ -109,11 +109,12 @@ html, body {
 		padding: 0;
 	}
 	#soundcloud-player .col-left {
+		background-color: white;
 		padding-top: 10%;
-		width: 100%;
 		height: 100%;
 		display: none;
 		position: fixed;
+		width: 100% !important;
 	}
 	#soundcloud-player .col-right {
 		width: 100%;
@@ -125,6 +126,7 @@ html, body {
 		box-sizing: border-box;
 		padding-left: 0%;
 		font-size: 70%;
+		display: block;
 	}
 	#playlistBtn {
 		background-color: #292929;

--- a/SoundCloudPlayer/styles/main.css
+++ b/SoundCloudPlayer/styles/main.css
@@ -137,7 +137,7 @@ html, body {
 		display: block;
 		font-size: 1em;
 		width: 100%;
-		height: 100%;
+		height: 50px;
 	}
 	#mobileBtn {
 		width: 100%;

--- a/SoundCloudPlayer/styles/main.css
+++ b/SoundCloudPlayer/styles/main.css
@@ -66,8 +66,8 @@ html, body {
 }
 
 .image-img{
-	width: 290px;
-	height:290px;
+	width: 100%;
+	height:100%;
 }
 
 #playlistBtn {


### PR DESCRIPTION
When you were in mobile mode with no playlist items selected and you were to view the playlist, the button would stretch down to the bottom of the screen.

I was asked to implement a redirect to playlist when selecting a song in mobile mode. 